### PR TITLE
Meta autocomplete fix

### DIFF
--- a/src-php/Models/Event.php
+++ b/src-php/Models/Event.php
@@ -30,7 +30,7 @@ class Event extends Model
         'end_date',
     ];
 
-    private $metaDefaults = [
+    protected $metaDefaults = [
         'browser_title' => 'title',
         'h1' => 'title',
         'nav_title' => 'title',

--- a/src-php/Models/Event.php
+++ b/src-php/Models/Event.php
@@ -30,6 +30,26 @@ class Event extends Model
         'end_date',
     ];
 
+    private $metaDefaults = [
+        'browser_title' => 'title',
+        'h1' => 'title',
+        'nav_title' => 'title',
+    ];
+
+    protected $appends = [
+        'name',
+    ];
+
+    /**
+     * For meta attributes and repeaters that look for a name field (Hyperlink blocks)
+     *
+     * @return String
+     */
+    public function getNameAttribute()
+    {
+        return $this->title;
+    }
+
     /**
      * Get only ongoing events
      *

--- a/src-php/Models/EventCategory.php
+++ b/src-php/Models/EventCategory.php
@@ -16,6 +16,26 @@ class EventCategory extends Model
 
     protected $table = 'nova_event_categories';
 
+    private $metaDefaults = [
+        'browser_title' => 'title',
+        'h1' => 'title',
+        'nav_title' => 'title',
+    ];
+
+    protected $appends = [
+        'name',
+    ];
+
+    /**
+     * For meta attributes and repeaters that look for a name field (Hyperlink blocks)
+     *
+     * @return String
+     */
+    public function getNameAttribute()
+    {
+        return $this->title;
+    }
+
     public function events()
     {
         return $this->belongsToMany(config('nova-events.models.event', Event::class), 'nova_event_categories_nova_events', 'nova_event_category_id', 'nova_event_id');

--- a/src-php/Models/EventCategory.php
+++ b/src-php/Models/EventCategory.php
@@ -16,7 +16,7 @@ class EventCategory extends Model
 
     protected $table = 'nova_event_categories';
 
-    private $metaDefaults = [
+    protected $metaDefaults = [
         'browser_title' => 'title',
         'h1' => 'title',
         'nav_title' => 'title',

--- a/src-php/Models/EventLocation.php
+++ b/src-php/Models/EventLocation.php
@@ -17,6 +17,26 @@ class EventLocation extends Model
 
     protected $table = 'nova_event_locations';
 
+    private $metaDefaults = [
+        'browser_title' => 'title',
+        'h1' => 'title',
+        'nav_title' => 'title',
+    ];
+
+    protected $appends = [
+        'name',
+    ];
+
+    /**
+     * For meta attributes and repeaters that look for a name field (Hyperlink blocks)
+     *
+     * @return String
+     */
+    public function getNameAttribute()
+    {
+        return $this->title;
+    }
+
     public function eventSlots()
     {
         return $this->hasMany(config('nova-events.models.event-slot', EventSlot::class), 'event_location_id', 'id');

--- a/src-php/Models/EventLocation.php
+++ b/src-php/Models/EventLocation.php
@@ -17,7 +17,7 @@ class EventLocation extends Model
 
     protected $table = 'nova_event_locations';
 
-    private $metaDefaults = [
+    protected $metaDefaults = [
         'browser_title' => 'title',
         'h1' => 'title',
         'nav_title' => 'title',


### PR DESCRIPTION
Set metaDefaults on models and set name attribute for common use in navigation and other blocks.

Can probably make this the 1.0.0 release too. Would be good to get away from the 0.x